### PR TITLE
[Fix]テストが通るようにバグを修正

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,7 +47,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|
@@ -62,7 +62,7 @@ module ReversiMethods
 
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
-    return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == attack_stone_color || target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)
@@ -86,6 +86,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    false
   end
 
   def count_stone(board, stone_color)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -62,7 +62,8 @@ module ReversiMethods
 
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
-    return false if target_pos.stone_color(board) == attack_stone_color || target_pos.stone_color(board) == BLANK_CELL
+    return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)


### PR DESCRIPTION
## 概要
リバーシプログラムのバグを修正しました。
1. 石の代入先の二重座標の記述を修正
2. となりに石がない場合はturnメソッドでfalseを返すように追記
3. placeable?でfalseを返すように追記

## テスト実行結果
```
# jun.k @ mcbk in ~/workspace/fjord/bug_reversi on git:debug o [11:40:42]
$ ruby test/reversi_methods_test.rb
Run options: --seed 45871

# Running:

.........

Finished in 0.007486s, 1202.2442 runs/s, 2404.4884 assertions/s.

9 runs, 18 assertions, 0 failures, 0 errors, 0 skips
```